### PR TITLE
docs: Add information on how to install cargo-generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,16 @@ Personal template to create rust projects using `cargo-generate`
 How to use:
 ```sh
 REPOSITORY="git@github.com:repo/repo.git"
-cargo generate --git https://github.com/jcvenegas/rust-template.git
-cd <new-project>
+git_name=$(basename "${REPOSITORY}")
+git_name="${git_name/.git/}"
+cargo install cargo-generate --features vendored-openssl
+cargo generate --git https://github.com/jcvenegas/rust-template.git  --name "${git_name}"
+cd "${git_name}"
 git remote add origin "${REPOSITORY}"
 ./.ci/setup.sh
 ./.ci/run.sh
 git add .ci/ .github/ .gitignore .travis.yml *
-git commit -s
+git commit -s -m "init"
 git push origin master
 ```
 


### PR DESCRIPTION
Add information on how to install cargo-generate useful to not go and search out of the docs.